### PR TITLE
Now setting the default tz to UTC

### DIFF
--- a/exoline/exo.py
+++ b/exoline/exo.py
@@ -1627,7 +1627,7 @@ def read_cmd(er, cik, rids, args):
             elif timeformat == 'iso8601':
                 dt = datetime.isoformat(pytz.utc.localize(datetime.utcfromtimestamp(timestamp)))
             else:
-                dt = tz.localize(datetime.utcfromtimestamp(timestamp))
+                dt = tz.localize(datetime.fromtimestamp(timestamp))
 
             row = {'timestamp': str(dt)}
 


### PR DESCRIPTION
If the local tz can not be determined, we now default to
UTC.
