### PR TITLE
Timezone fix for systems that timezone can't be programmatically determined

### DIFF
--- a/exoline/exo.py
+++ b/exoline/exo.py
@@ -1556,19 +1556,14 @@ def read_cmd(er, cik, rids, args):
         try:
             tz = timezone.localtz()
         except pytz.UnknownTimeZoneError as e:
-            print('Unable to detect local time zone, defaulting to UTC')
+            # Unable to detect local time zone, defaulting to UTC
             tz = pytz.utc
     else:
         try:
             tz = pytz.timezone(tz)
         except Exception as e:
             #default to utc if error
-            print('Error parsing --tz option, defaulting to local timezone')
-            try:
-                tz = timezone.localtz()
-            except pytz.UnknownTimeZoneError as e:
-                print('Unable to detect local time zone, defaulting to UTC')
-                tz = pytz.utc
+            raise ExoException('Error parsing --tz option, defaulting to local timezone')
 
     recarriage = re.compile('\r(?!\\n)')
 


### PR DESCRIPTION
 Was previously incorrectly handling the case when the timezone couldn't be automatically
determined.  

Also removing some debug output that was causing tests to fail.
