### PR TITLE
Proposing fix for the Python 3.4 breakage in using exoline as a library....

### DIFF
--- a/exoline/exo.py
+++ b/exoline/exo.py
@@ -415,7 +415,10 @@ if platform.system() != 'Windows':
             try:
                 plugin = importlib.import_module('plugins.' + module_name)
             except:
-                plugin = importlib.import_module('exoline.plugins.' + module_name, package='test')
+                try:
+                    plugin = importlib.import_module('exoline.plugins.' + module_name, package='test')
+                except:
+                    plugin = importlib.import_module('exoline.plugins.' + module_name)
 
             # instantiate plugin
             p = plugin.Plugin()


### PR DESCRIPTION
... Issue #20 will likely be fixed by this.

I verified this doesn't break python 2.7 and verified it works on 3.4. I'm not sure what the "package='test'" argument is for, but reading up on the importlib.import_module() function, it doesn't make sense to me to have it since having the argument suggests a relative-path import (e.g. '..plugins.' + module_name, package='test'). 

I used print statements to inspect the values of plugin_path, plugin_names and module_name during the imports.

In the 2.7 case the plugin path was '/Library/Python/2.7/site-packages/exoline/plugins'.

In the 3.4 case it was '/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/exoline/plugins'.

It might not be the best fix, but it allows for usage as a library in 3.4.

Thanks,

~Will
