### PR TITLE
Allow Integer ciks for shortcuts

### DIFF
--- a/exoline/exo.py
+++ b/exoline/exo.py
@@ -592,9 +592,11 @@ class ExoConfig:
             if 'keys' in self.config:
                 if cik in self.config['keys']:
                     return self.config['keys'][cik].strip()
-                else:
+                elif int(cik) in self.config['keys']:
+                    return self.config['keys'][int(cik)].strip()
+                else:                
                     raise ExoException('No CIK shortcut {0}\n{1}'.format(
-                        cik, '\n'.join(sorted(self.config['keys']))))
+                        cik, '\n'.join(sorted(map(str, self.config['keys'])))))
             else:
                 raise ExoException('Tried a CIK shortcut {0}, but found no keys'.format(cik))
         else:

--- a/exoline/exo.py
+++ b/exoline/exo.py
@@ -592,7 +592,7 @@ class ExoConfig:
             if 'keys' in self.config:
                 if cik in self.config['keys']:
                     return self.config['keys'][cik].strip()
-                elif int(cik) in self.config['keys']:
+                elif cik.isdigit() and int(cik) in self.config['keys']:
                     return self.config['keys'][int(cik)].strip()
                 else:                
                     raise ExoException('No CIK shortcut {0}\n{1}'.format(


### PR DESCRIPTION
Allow integer ciks. Right now, if you try to access an integer cik there's an exception that occurs while throwing an except....

  File "exoline/bin/exo", line 597, in _lookup_shortcut
    cik, '\n'.join(sorted(self.config['keys']))))
TypeError: sequence item 0: expected string or Unicode, int found

Mapping the list of keys to strings fixes this, but it's likely better to add support for using integer keys. yaml seems to do the config parsing, so instead of mapping all the keys to strings, try seeing if an integer version of the CIK is present before raising the error that the key isn't present.