### PR TITLE
Allow twee to take up the whole terminal width

### DIFF
--- a/exoline/exo.py
+++ b/exoline/exo.py
@@ -58,7 +58,6 @@ import six
 from six import StringIO
 from six import iteritems
 from six import string_types
-
 # python 2.6 support
 try:
     from collections import OrderedDict
@@ -89,7 +88,6 @@ except:
     from exoline.exocommon import ExoException
     from exoline import exocommon
     from exoline import serieswriter
-
 
 DEFAULT_HOST = 'm2.exosite.com'
 DEFAULT_PORT = '80'
@@ -1589,9 +1587,6 @@ class ExoRPC():
                 ridopt = True
         add_opt(ridopt, 'rid', rid)
         add_opt('--verbose', 'unit', units)
-        val = self._format_values(values, 50 if twee else 20)
-        timestamp = self._format_timestamp(values)
-        add_opt(values is not None, 'value', None if (val is None or timestamp is None) else val + '/' + timestamp)
 
         if 'listing_option' in info and info['listing_option'] == 'activated':
             add_opt(True, 'share', True)
@@ -1601,6 +1596,10 @@ class ExoRPC():
             maxlen['type'] = len(typ)
             maxlen['name'] = len(name)
             maxlen['format'] = 0 if 'format' not in info['description'] else len(info['description']['format'])
+
+        val = self._format_values(values, sizex)
+        timestamp = self._format_timestamp(values)
+        add_opt(values is not None, 'value', None if (val is None or timestamp is None) else val + '/' + timestamp)
 
         if twee:
             # colors, of course
@@ -1644,6 +1643,23 @@ class ExoRPC():
             displaymodel = ''
             if 'sn' in opt and 'model' in opt:
                 displaymodel = ' (' + opt['model'] + '#' + opt['sn'] + ')'
+
+    
+            if val:
+                try:
+                    terminal_width, terminal_height = exocommon.get_terminal_size()
+                except:
+                    # Default to 80 chars
+                    sizex = 80
+
+                twee_line = "".join([spacer, displayname, ' '*( maxlen['name']+1- len(name)), displaytype, tweeid, (' (share)' if 'listing_option' in info and info['listing_option'] == 'activated' else ''), 
+                                    ('' if typ == 'client' else ': '), ('' if timestamp is None or len(timestamp) == 0 else ' (' + timestamp + ')'), displaymodel])
+                val_size = len(val)
+                displayed_chars = len(twee_line)
+                allowed_size = terminal_width-displayed_chars
+                if val_size > allowed_size:
+                    allowed_size -= 3
+                    val = val[:allowed_size] + "..."
 
             self._print_tree_line(
                 bcolors.SPACER +
@@ -2527,7 +2543,6 @@ probably not valid.".format(cik))
                 options[key] = True
 
         return options
-
 
 class ExoData():
     '''Implements the Data Interface API

--- a/exoline/exo.py
+++ b/exoline/exo.py
@@ -1597,7 +1597,13 @@ class ExoRPC():
             maxlen['name'] = len(name)
             maxlen['format'] = 0 if 'format' not in info['description'] else len(info['description']['format'])
 
-        val = self._format_values(values, sizex)
+        try:
+            terminal_width, terminal_height = exocommon.get_terminal_size()
+        except:
+            # Default to 80 chars
+            terminal_width = 80
+
+        val = self._format_values(values, terminal_width)
         timestamp = self._format_timestamp(values)
         add_opt(values is not None, 'value', None if (val is None or timestamp is None) else val + '/' + timestamp)
 
@@ -1646,12 +1652,6 @@ class ExoRPC():
 
     
             if val:
-                try:
-                    terminal_width, terminal_height = exocommon.get_terminal_size()
-                except:
-                    # Default to 80 chars
-                    sizex = 80
-
                 twee_line = "".join([spacer, displayname, ' '*( maxlen['name']+1- len(name)), displaytype, tweeid, (' (share)' if 'listing_option' in info and info['listing_option'] == 'activated' else ''), 
                                     ('' if typ == 'client' else ': '), ('' if timestamp is None or len(timestamp) == 0 else ' (' + timestamp + ')'), displaymodel])
                 val_size = len(val)

--- a/exoline/exocommon.py
+++ b/exoline/exocommon.py
@@ -65,7 +65,7 @@ def get_terminal_size():
     if current_os in ['Linux', 'Darwin'] or current_os.startswith('CYGWIN'):
         tuple_xy = _get_terminal_size_linux()
     if tuple_xy is None:
-        print "default"
+        print("default")
         tuple_xy = (80, 25)      # default value
     return tuple_xy
  
@@ -131,4 +131,4 @@ terminal_size = get_terminal_size
  
 if __name__ == "__main__":
     sizex, sizey = get_terminal_size()
-    print  'width =', sizex, 'height =', sizey
+    print('width =', sizex, 'height =', sizey)

--- a/exoline/exocommon.py
+++ b/exoline/exocommon.py
@@ -1,3 +1,9 @@
+import os
+import shlex
+import struct
+import platform
+import subprocess
+
 class ExoException(Exception):
     pass
 
@@ -37,4 +43,92 @@ class _GetchWindows:
         import msvcrt
         return msvcrt.getch()
 
+
+# From https://gist.github.com/jtriley/1108174
+# Which is from http://stackoverflow.com/questions/566746/how-to-get-console-window-width-in-python/6550596#6550596
+# which is from http://code.activestate.com/recipes/440694-determine-size-of-console-window-on-windows/ 
+
+def get_terminal_size():
+    """ getTerminalSize()
+     - get width and height of console
+     - works on linux,os x,windows,cygwin(windows)
+     originally retrieved from:
+     http://stackoverflow.com/questions/566746/how-to-get-console-window-width-in-python
+    """
+    current_os = platform.system()
+    tuple_xy = None
+    if current_os == 'Windows':
+        tuple_xy = _get_terminal_size_windows()
+        if tuple_xy is None:
+            tuple_xy = _get_terminal_size_tput()
+            # needed for window's python in cygwin's xterm!
+    if current_os in ['Linux', 'Darwin'] or current_os.startswith('CYGWIN'):
+        tuple_xy = _get_terminal_size_linux()
+    if tuple_xy is None:
+        print "default"
+        tuple_xy = (80, 25)      # default value
+    return tuple_xy
+ 
+def _get_terminal_size_windows():
+    try:
+        from ctypes import windll, create_string_buffer
+        # stdin handle is -10
+        # stdout handle is -11
+        # stderr handle is -12
+        h = windll.kernel32.GetStdHandle(-12)
+        csbi = create_string_buffer(22)
+        res = windll.kernel32.GetConsoleScreenBufferInfo(h, csbi)
+        if res:
+            (bufx, bufy, curx, cury, wattr,
+             left, top, right, bottom,
+             maxx, maxy) = struct.unpack("hhhhHhhhhhh", csbi.raw)
+            sizex = right - left + 1
+            sizey = bottom - top + 1
+            return sizex, sizey
+    except:
+        pass
+ 
+
+def _get_terminal_size_tput():
+    # get terminal width
+    # src: http://stackoverflow.com/questions/263890/how-do-i-find-the-width-height-of-a-terminal-window
+    try:
+        cols = int(subprocess.check_call(shlex.split('tput cols')))
+        rows = int(subprocess.check_call(shlex.split('tput lines')))
+        return (cols, rows)
+    except:
+        pass
+ 
+ 
+def _get_terminal_size_linux():
+    def ioctl_GWINSZ(fd):
+        try:
+            import fcntl
+            import termios
+            cr = struct.unpack('hh',
+                               fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))
+            return cr
+        except:
+            pass
+    cr = ioctl_GWINSZ(0) or ioctl_GWINSZ(1) or ioctl_GWINSZ(2)
+    if not cr:
+        try:
+            fd = os.open(os.ctermid(), os.O_RDONLY)
+            cr = ioctl_GWINSZ(fd)
+            os.close(fd)
+        except:
+            pass
+    if not cr:
+        try:
+            cr = (os.environ['LINES'], os.environ['COLUMNS'])
+        except:
+            return None
+    return int(cr[1]), int(cr[0])
+
 getch = _Getch()
+
+terminal_size = get_terminal_size
+ 
+if __name__ == "__main__":
+    sizex, sizey = get_terminal_size()
+    print  'width =', sizex, 'height =', sizey


### PR DESCRIPTION
This pull request allows the twee command to take up the entire width of the line that it is printed on. 

If the line is longer than the space allowed it still adds the ellipsis to allow the user to know that the data didn't hit the end.

I tested it and it seemed to not break anything on 3.4 and 2.7, but no guarantees on that. 