### PR TITLE
Fixes IOError with spec --generate and no scripts dir.

### DIFF
--- a/exoline/plugins/spec.py
+++ b/exoline/plugins/spec.py
@@ -650,6 +650,7 @@ datarules:
                             desc = myinfo['description']
                             is_script = desc['format'] == 'string' and 'rule' in desc and 'script' in desc['rule']
                             if is_script:
+                                os.makedirs(script_dir)
                                 filename = os.path.join(script_dir, info['aliases'][rid][0])
                                 spec.setdefault('scripts', []).append({'file': filename})
                                 with open(filename, 'w') as f:


### PR DESCRIPTION
If you run `exo spec <cik> --generate=<target>` and there is no scripts
directory present, an IOError is thrown because it attempts to create
the script files associated with the CIK in a directory which doesn't
exist. This makes sure that directory exists before writing the files.