### PR TITLE
Added missing auth token

### DIFF
--- a/exoline/exo.py
+++ b/exoline/exo.py
@@ -1183,7 +1183,7 @@ class ExoRPC():
                         chunkOpt['limit'] = chunksize
                     else:
                         chunkOpt['limit'] = maxLimit
-                    res = _read(cik, rids, chunkOpt);
+                    res = _read(auth, rids, chunkOpt);
                     for r in res:
                         yield r
                     if len(res) == 0:
@@ -1207,7 +1207,7 @@ class ExoRPC():
                         chunkOpt['limit'] = chunksize
                     else:
                         chunkOpt['limit'] = maxLimit
-                    res = _read(cik, rids, chunkOpt)
+                    res = _read(auth, rids, chunkOpt)
                     for r in res:
                         yield r
                     if len(res) == 0:


### PR DESCRIPTION
Fixes the following traceback:

Traceback (most recent call last):
  File "daily_dump.py", line 118, in <module>
    dump_company_data('basco', basco_ciks)
  File "daily_dump.py", line 113, in dump_company_data
    dump_device_data(cik, workbook, format_date_time)
  File "daily_dump.py", line 57, in dump_device_data
    '--limit=100000'])
  File "/usr/local/lib/python2.7/dist-packages/exoline-0.10.0-py2.7.egg/exoline/exo.py", line 3678, in run
    exitcode = cmd(argv=argv, stdin=stdin, stdout=stdout, stderr=stderr)
  File "/usr/local/lib/python2.7/dist-packages/exoline-0.10.0-py2.7.egg/exoline/exo.py", line 3613, in cmd
    exitcode = handle_args(cmd, args)
  File "/usr/local/lib/python2.7/dist-packages/exoline-0.10.0-py2.7.egg/exoline/exo.py", line 3071, in handle_args
    read_cmd(er, auth, rids, args)
  File "/usr/local/lib/python2.7/dist-packages/exoline-0.10.0-py2.7.egg/exoline/exo.py", line 2968, in read_cmd
    for t, v in result:
  File "/usr/local/lib/python2.7/dist-packages/exoline-0.10.0-py2.7.egg/exoline/exo.py", line 1186, in readmult
    res = _read(cik, rids, chunkOpt);
NameError: global name 'cik' is not defined